### PR TITLE
Better nested directives support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var tagalong = function(node, data, directives) {
 
   if (typeof directives === 'object') {
     directives = expandKeys(directives);
-    applyDirectives(node, data, directives);
   } else if (typeof directives === 'function') {
     directives = directives.call(node, data) || {};
   } else {
@@ -18,7 +17,11 @@ var tagalong = function(node, data, directives) {
 
   if (Array.isArray(data)) {
     return bindArray(node, data, directives);
-  } else if (typeof data === 'object') {
+  } else {
+    applyDirectives(node, data, directives);
+  }
+
+  if (typeof data === 'object') {
     return bindObject(node, data, directives);
   }
 
@@ -107,34 +110,45 @@ function getChildren(node) {
   return children;
 }
 
-function access(getter, data, thisArg) {
-  if (typeof getter === 'function') {
-    return getter.call(thisArg, data);
-  }
-  return data[getter];
-}
-
 function applyDirectives(node, data, directives) {
+  function access(key, attr) {
+    var value = directives[key];
+    if (typeof value === 'function') {
+      return value.call(node, data);
+    } if (value === true) {
+      return data[attr || key];
+    }
+    return (typeof value === 'object')
+      ? value
+      : data[value];
+  }
+
   var interpolated;
   for (var key in directives) {
     if (key.charAt(0) === '@') {
       var attr = key.substr(1);
-      var value = directives[key] === true
-        ? data[attr]
-        : access(directives[key], data, node);
+      var value = access(key, attr) || '';
       node.setAttribute(attr, value);
     } else {
-      // only interpolate scalars and functions;
-      // nested directives apply to children
-      if (typeof directives[key] !== 'object') {
+      switch (key) {
+        case 'text':
+          node.textContent = access(key) || '';
+          break;
+      }
+      if (typeof directives[key] === 'object') {
+        bindKey(node, key, data, directives[key]);
+      } else {
         if (!interpolated) interpolated = {};
-        interpolated[key] = access(directives[key], data, node);
+        interpolated[key] = access(key);
       }
     }
   }
+
   if (interpolated) {
-    tagalong(node, interpolated);
+    return tagalong(node, interpolated);
   }
+
+  return node;
 }
 
 function expandKeys(obj) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -131,6 +131,16 @@ describe('tagalong', function() {
         assert.equal(span.textContent, 'foo');
       });
 
+      it('interpolates nested directives', function() {
+        var div = document.createElement('div');
+        var span = div.appendChild(document.createElement('span'));
+        span.className = 'x';
+        var b = span.appendChild(document.createElement('b'));
+        b.className = 'y';
+        tagalong(div, {y: 'foo'}, {x: {y: 'y'}});
+        assert.equal(b.textContent, 'foo');
+      });
+
     }); // directive interpolation
 
   }); // object binding
@@ -193,6 +203,27 @@ describe('tagalong', function() {
       assert.equal(lis.length, 2);
       assert.equal(lis[0].firstChild.textContent, 'x');
       assert.equal(lis[1].firstChild.textContent, 'y');
+    });
+
+    it('binds directives to individual array elements', function() {
+      var list = document.createElement('ul');
+      var item = list.appendChild(document.createElement('li'));
+      var link = item.appendChild(document.createElement('a'));
+      link.className = 'link';
+
+      var data = [
+        {text: 'foo', href: 'foo.html'},
+        {text: 'bar', href: 'bar.html'}
+      ];
+      tagalong(list, data, {
+        link: {
+          text: 'text',
+          '@href': 'href'
+        }
+      });
+      var links = list.querySelectorAll('li a');
+      assert.equal(links[0].getAttribute('href'), 'foo.html');
+      assert.equal(links[0].textContent, 'foo');
     });
 
   }); // array binding


### PR DESCRIPTION
This PR improves support for nested directives, which makes it possible to populate text and attributes on an arbitrarily nested element like so:

``` html
<ul id="template">
  <ul class="items">
    <li><a class="link"></a></li>
  </ul>
</div>
<script>
tagalong('#template', [
  {text: 'foo', href: '1.html'},
  {text: 'bar', href: '2.html'}
], {
  link: {
    text: 'foo',
    '@href': 'href'
  }
});
</script>
```
