### PR TITLE
Add support for comments and interpolation w/in

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -33,6 +33,13 @@ var createTextRenderer = function(node) {
   return compose.stringify(interpolate.compile(node.nodeValue));
 };
 
+var createCommentRenderer = function(node) {
+  var value = compose.stringify(interpolate.compile(node.nodeValue));
+  return function() {
+    return document.createComment(value.apply(this, arguments));
+  };
+};
+
 /**
  * "Pluck" event handlers from an attribute map, removing them from
  * the map. If no event handlers are found, the return value is
@@ -298,8 +305,12 @@ var compile = function(node) {
   switch (node.nodeType) {
     case 1: // Node.ELEMENT_NODE
       return createElementRenderer(node);
+
     case 3: // Node.TEXT_NODE
       return createTextRenderer(node);
+
+    case 8: // Node.COMMENT_NODE
+      return createCommentRenderer(node);
 
     // TODO: support document fragments?
     // this would need support in h()

--- a/test/render.js
+++ b/test/render.js
@@ -60,6 +60,18 @@ describe('render()', function() {
     assert.equal(root.innerHTML, '<div>baz</div>');
   });
 
+  it('preserves comments', function() {
+    var html = root.innerHTML = 'foo <!-- bar --> baz';
+    tagalong.render(root, {});
+    assert.equal(root.innerHTML, html);
+  });
+
+  it('interpolates comments', function() {
+    var html = root.innerHTML = 'foo <!-- {{ x }} --> baz';
+    tagalong.render(root, {x: 'bar'});
+    assert.equal(root.innerHTML, 'foo <!-- bar --> baz');
+  });
+
   describe('t- attributes', function() {
     it('renders expression attributes with the "t-" prefix', function() {
       root.innerHTML = '<div t-id="foo.bar">hi</div>';


### PR DESCRIPTION
Previously, compiling an element that contained comments throw an error: `no renderer for node type: 8` (8 is `Node.COMMENT_NODE`). This adds support for comment rendering and allows you to interpolate expressions in your comments, which might be helpful for debugging.
